### PR TITLE
allow to ignore enabled status check and to replace 'is-active' check by NOT 'is-failed' one

### DIFF
--- a/check_systemd_service
+++ b/check_systemd_service
@@ -22,6 +22,8 @@ Usage:
 Options:
     [service]           name of systemd service for check
     --restart           restart service if is not running
+    --inverse           use !is-failed as status
+    --no-enable         does not check if enabled or not
     -V, --version       current version of plugin
     -h, --help          plugin help and usage
 
@@ -74,6 +76,14 @@ case "$2" in
     RESTART=YES
     shift
     ;;
+    --inverse)
+    INVERSE=YES
+    shift
+    ;;
+    --no-enable)
+    ENABLE=NO
+    shift
+    ;;
     *)
     # unknown option, save
     POSITIONAL+=("$2")
@@ -102,13 +112,16 @@ if [[ -z "$status" ]]; then
 fi
 
 # alternative state
-if [[ $ret -ne 0 ]]; then
+if [[ $ret -ne 0 ]] && [[ -z "$ENABLE" ]]; then
     echo "ERROR: service $service is $status"
     exit $STATE_CRITICAL
 fi
 
 # check if is or is not running
 systemctl --quiet is-active $service
+if [[ ! -z "$INVERSE" ]]; then
+    status=$(! systemctl is-failed $service 2>/dev/null)
+fi
 
 if [[ $? -ne 0 ]]; then
     if [[ ! -z "$RESTART" ]]; then


### PR DESCRIPTION
This allow to monitor the last status of timer-triggered units

For example :
```
root@prod-srv-02:/home/ubuntu# systemctl status mongobackup.service
● mongobackup.service - Backup Mongodb
     Loaded: loaded (/etc/systemd/system/mongobackup.service; static; vendor preset: enabled)
     Active: failed (Result: exit-code) since Fri 2021-02-26 11:37:40 UTC; 45s ago
TriggeredBy: ● mongobackup.timer
    Process: 4041687 ExecStart=/var/archives/mongo/backup.sh (code=exited, status=1/FAILURE)
   Main PID: 4041687 (code=exited, status=1/FAILURE)
root@prod-srv-02:/home/ubuntu# /usr/lib/nagios/plugins/check_systemd_service mongobackup.service
OK: service mongobackup.service is running
root@prod-srv-02:/home/ubuntu# /usr/lib/nagios/plugins/check_systemd_service mongobackup.service --inverse
ERROR: service mongobackup.service is not running
```
and after correcting script:
```
root@prod-srv-02:/home/ubuntu# systemctl status mongobackup.service
● mongobackup.service - Backup Mongodb
     Loaded: loaded (/etc/systemd/system/mongobackup.service; static; vendor preset: enabled)
     Active: inactive (dead) since Fri 2021-02-26 11:48:44 UTC; 1min 0s ago
TriggeredBy: ● mongobackup.timer
    Process: 4043325 ExecStart=/var/archives/mongo/backup.sh (code=exited, status=0/SUCCESS)
   Main PID: 4043325 (code=exited, status=0/SUCCESS)
root@prod-srv-02:/home/ubuntu# /usr/lib/nagios/plugins/check_systemd_service mongobackup.service --inverse
OK: service mongobackup.service is running
root@prod-srv-02:/home/ubuntu# /usr/lib/nagios/plugins/check_systemd_service mongobackup.service
OK: service mongobackup.service is running
```
